### PR TITLE
added content type locale fetching

### DIFF
--- a/packages/lastrev-build-prefetch-content/lastrevrc-schema.json
+++ b/packages/lastrev-build-prefetch-content/lastrevrc-schema.json
@@ -209,20 +209,33 @@
     "LocalesConfig": {
       "additionalProperties": false,
       "properties": {
+        "localizationItemContentTypeId": {
+          "type": "string"
+        },
         "localizationLookupFieldName": {
           "type": "string"
+        },
+        "localizationSetContentTypeId": {
+          "type": "string"
+        },
+        "lookupType": {
+          "$ref": "#/definitions/LocalizationLookupType"
         },
         "outputPath": {
           "type": "string"
         },
         "rawPagesDir": {
           "type": "string"
-        },
-        "useV1": {
-          "type": "boolean"
         }
       },
       "type": "object"
+    },
+    "LocalizationLookupType": {
+      "enum": [
+        "JSON",
+        "Content"
+      ],
+      "type": "string"
     },
     "MappingConfig": {
       "additionalProperties": false,

--- a/packages/lastrev-build-prefetch-content/src/constants.ts
+++ b/packages/lastrev-build-prefetch-content/src/constants.ts
@@ -1,6 +1,7 @@
 import { readFileSync } from 'fs';
 import { resolve } from 'path';
 import findProjectRoot from './helpers/findProjectRoot';
+import { LocalizationLookupType } from './types';
 
 export const PROJECT_ROOT = findProjectRoot();
 
@@ -24,3 +25,6 @@ export const DEFAULT_LOCALES_OUTPUT_DIRNAME = 'locales';
 export const DEFAULT_UNTRANSLATED_PAGES_DIRNAME = 'src/_pages';
 export const DEFAULT_TRANSLATED_PAGES_DIRNAME = 'src/pages';
 export const DEFAULT_SLUG_FIELD = 'slug';
+export const DEFAULT_LOCALES_LOOKUP_TYPE: LocalizationLookupType = 'JSON';
+export const DEFAULT_LOCALIZATION_ITEM_CONTENT_TYPE = 'localizedStaticContentItem';
+export const DEFAULT_LOCALIZATION_SET_CONTENT_TYPE = 'localizedStaticContentSet';

--- a/packages/lastrev-build-prefetch-content/src/helpers/resolveConfig.ts
+++ b/packages/lastrev-build-prefetch-content/src/helpers/resolveConfig.ts
@@ -1,7 +1,13 @@
 import { resolve } from 'path';
 import { get, chain, identity } from 'lodash';
 
-import { BuildConfig, ResolvedBuildConfig, SwitchesBuildConfig, FileLocationsBuildConfig } from '../types';
+import {
+  BuildConfig,
+  ResolvedBuildConfig,
+  SwitchesBuildConfig,
+  FileLocationsBuildConfig,
+  LocalesConfig
+} from '../types';
 import {
   PROJECT_ROOT,
   DEFAULT_OUTPUT_DIRNAME,
@@ -14,7 +20,11 @@ import {
   DEFAULT_SETTINGS_FILENAME,
   DEFAULT_UNTRANSLATED_PAGES_DIRNAME,
   DEFAULT_LOCALES_OUTPUT_DIRNAME,
-  DEFAULT_TRANSLATED_PAGES_DIRNAME
+  DEFAULT_TRANSLATED_PAGES_DIRNAME,
+  DEFAULT_LOCALES_LOOKUP_TYPE,
+  DEFAULT_LOCALIZATION_LOOKUP_FIELD_NAME,
+  DEFAULT_LOCALIZATION_ITEM_CONTENT_TYPE,
+  DEFAULT_LOCALIZATION_SET_CONTENT_TYPE
 } from '../constants';
 
 const resolveSwitches = (buildConfig: BuildConfig): SwitchesBuildConfig => {
@@ -78,13 +88,37 @@ const resolveFileLocations = (buildConfig: BuildConfig): FileLocationsBuildConfi
   };
 };
 
+const resolveLocalesConfigValues = (buildConfig: BuildConfig): LocalesConfig => {
+  return {
+    ...buildConfig.locales,
+    lookupType: get(buildConfig, 'locales.lookupType', DEFAULT_LOCALES_LOOKUP_TYPE),
+    localizationLookupFieldName: get(
+      buildConfig,
+      'locales.localizationLookupFieldName',
+      DEFAULT_LOCALIZATION_LOOKUP_FIELD_NAME
+    ),
+    localizationItemContentTypeId: get(
+      buildConfig,
+      'locales.localizationItemContentTypeId',
+      DEFAULT_LOCALIZATION_ITEM_CONTENT_TYPE
+    ),
+    localizationSetContentTypeId: get(
+      buildConfig,
+      'locales.localizationSetContentTypeId',
+      DEFAULT_LOCALIZATION_SET_CONTENT_TYPE
+    )
+  };
+};
+
 export default (buildConfig: BuildConfig): ResolvedBuildConfig => {
   const switches = resolveSwitches(buildConfig);
   const fileLocations = resolveFileLocations(buildConfig);
+  const locales = resolveLocalesConfigValues(buildConfig);
 
   return {
     ...buildConfig,
     ...switches,
-    ...fileLocations
+    ...fileLocations,
+    locales
   };
 };

--- a/packages/lastrev-build-prefetch-content/src/types.ts
+++ b/packages/lastrev-build-prefetch-content/src/types.ts
@@ -5,6 +5,8 @@ export type MappingConfig = {
   exclude?: string[];
 };
 
+export type LocalizationLookupType = 'JSON' | 'Content';
+
 export type LocalesConfig = {
   localizationLookupFieldName?: string;
   /**
@@ -15,7 +17,9 @@ export type LocalesConfig = {
    * @deprecated
    */
   outputPath?: string;
-  useV1?: boolean;
+  lookupType?: LocalizationLookupType;
+  localizationItemContentTypeId?: string;
+  localizationSetContentTypeId?: string;
 };
 
 export type PathChildrenConfig = {

--- a/packages/lastrev-integration-contentful/src/getLocalizationLookup/getLocalizationLookup.ts
+++ b/packages/lastrev-integration-contentful/src/getLocalizationLookup/getLocalizationLookup.ts
@@ -19,7 +19,8 @@ const getLocalizationLookup = (client) => async ({
         'content_type': contentTypeId,
         'select': `sys,fields.${localizationLookupFieldName}`,
         'sys.id': process.env.CONTENTFUL_SETTINGS_ID,
-        'locale': code
+        'locale': code,
+        'include': 2
       })
     );
   }

--- a/packages/lastrev-integration-contentful/src/types.ts
+++ b/packages/lastrev-integration-contentful/src/types.ts
@@ -1,4 +1,4 @@
-import { Entry } from 'contentful';
+import { Entry, EntryCollection } from 'contentful';
 
 export { Entry } from 'contentful';
 
@@ -42,6 +42,6 @@ export type SyncAllEntriesAndAssetsConfig = {
   contentTypeId: string;
 };
 
-export type LocalizationLookupMapping = Record<string, Record<string, string>>;
+export type LocalizationLookupMapping = Record<string, any>;
 
 export type StaticSlugResult = string | [string, Entry<unknown>[]];


### PR DESCRIPTION
IN this change:
- Added a `lookupType` property on the locales config object, which defaults to the (old) JSON type.
- if `lookupType` == "Content", will assume the field is a multi-select field of two possible content types
- new configuration to add these content types, defaulting to `localizedStaticContentItem` and `localizedStaticContentSet`
- will build out the locales json based on `key` and `value` fields of the singe item type, or same fields in the references array of the multiple item type. Newer values override older ones.