### PR TITLE
Import specific lodash functions in settings

### DIFF
--- a/packages/lastrev-build-prefetch-content/templates/settings.js.hbs
+++ b/packages/lastrev-build-prefetch-content/templates/settings.js.hbs
@@ -1,4 +1,5 @@
-import _ from 'lodash';
+import get from 'lodash/get';
+import find from 'lodash/find';
 
 const localeToSettingsMap = {
   {{#each settingsByLocale}}
@@ -10,8 +11,8 @@ const localeToSettingsMap = {
 };
 
 function getSettings(locale) {
-  const obj = _.get(localeToSettingsMap, locale) || _.find(localeToSettingsMap, 'isDefault');
-  return _.get(obj, 'settings');
+  const obj = get(localeToSettingsMap, locale) || find(localeToSettingsMap, 'isDefault');
+  return get(obj, 'settings');
 }
 
 export default getSettings;


### PR DESCRIPTION
Since settings.js gets imported and passed to pages, all of lodash ends up being bundled. 

This just makes the written `settings.js` use a tree-shakable version of lodash.