### PR TITLE
Add max traverse depth to support objects with circular references

### DIFF
--- a/packages/lastrev-adapter-contentful/package.json
+++ b/packages/lastrev-adapter-contentful/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@last-rev/adapter-contentful",
-  "version": "4.3.2-alpha.0",
+  "version": "4.3.2-alpha.1",
   "description": "Transforms data from contentful's structure to one which is expected by LastRev components",
   "main": "dist/index.js",
   "files": [

--- a/packages/lastrev-adapter-contentful/package.json
+++ b/packages/lastrev-adapter-contentful/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@last-rev/adapter-contentful",
-  "version": "4.3.1",
+  "version": "4.3.2-alpha.0",
   "description": "Transforms data from contentful's structure to one which is expected by LastRev components",
   "main": "dist/index.js",
   "files": [

--- a/packages/lastrev-adapter-contentful/src/contentfulAdapter/contentfulAdapter.ts
+++ b/packages/lastrev-adapter-contentful/src/contentfulAdapter/contentfulAdapter.ts
@@ -23,7 +23,7 @@ const Adapter = <T>({
   const parsedEntries: Record<string, ParsedEntry> = {};
 
   const traverse = (obj: unknown, maxDepth: number = maxTraverseDepth) => {
-    if (maxDepth == 0) return null;
+    if (maxDepth < 0) return null;
 
     if (isBadContentfulObject(obj)) {
       return null;

--- a/packages/lastrev-adapter-contentful/src/contentfulAdapter/contentfulAdapter.ts
+++ b/packages/lastrev-adapter-contentful/src/contentfulAdapter/contentfulAdapter.ts
@@ -17,16 +17,19 @@ const Adapter = <T>({
   contentRefTypeText = 'Content reference',
   assetRefTypeText = 'Asset reference',
   contentUrlLookup,
-  skipContentTypes
+  skipContentTypes,
+  maxTraverseDepth = 10
 }: AdapterConfig): Transform => (data) => {
   const parsedEntries: Record<string, ParsedEntry> = {};
 
-  const traverse = (obj: unknown) => {
+  const traverse = (obj: unknown, maxDepth: number = maxTraverseDepth) => {
+    if (maxDepth == 0) return null;
+
     if (isBadContentfulObject(obj)) {
       return null;
     }
     if (isArray(obj)) {
-      return compact(map(obj, traverse)) as unknown[];
+      return compact(map(obj, (x) => traverse(x, maxDepth - 1))) as unknown[];
     }
     if (isLink(obj, linkContentType)) {
       return parseLink({
@@ -52,7 +55,9 @@ const Adapter = <T>({
       }
       const parsed = parseEntry(obj as Entry<Record<string, unknown>>, urlMap, contentUrlLookup);
       parsedEntries[parsed._id] = parsed;
-      const parsedFields: Record<string, unknown> = mapValues((obj as Entry<Record<string, unknown>>).fields, traverse);
+      const parsedFields: Record<string, unknown> = mapValues((obj as Entry<Record<string, unknown>>).fields, (x) =>
+        traverse(x, maxDepth - 1)
+      );
       return {
         ...parsed,
         ...parsedFields
@@ -62,13 +67,13 @@ const Adapter = <T>({
       return parseAsset(obj as Asset);
     }
     if (isObject(obj)) {
-      return mapValues(obj, traverse);
+      return mapValues(obj, (x) => traverse(x, maxDepth - 1));
     }
     // most likely a simple value field
     return obj;
   };
 
-  return traverse(data) as TransformResult<typeof data>;
+  return traverse(data, maxTraverseDepth) as TransformResult<typeof data>;
 };
 
 export default Adapter;

--- a/packages/lastrev-adapter-contentful/src/contentfulAdapter/contentfulAdapter.ts
+++ b/packages/lastrev-adapter-contentful/src/contentfulAdapter/contentfulAdapter.ts
@@ -67,7 +67,8 @@ const Adapter = <T>({
       return parseAsset(obj as Asset);
     }
     if (isObject(obj)) {
-      return mapValues(obj, (x) => traverse(x, maxDepth - 1));
+      // No need to reduce maxDepth as we're not following a reference
+      return mapValues(obj, (x) => traverse(x, maxDepth));
     }
     // most likely a simple value field
     return obj;

--- a/packages/lastrev-adapter-contentful/src/types.ts
+++ b/packages/lastrev-adapter-contentful/src/types.ts
@@ -71,6 +71,7 @@ export type AdapterConfig = {
   assetRefTypeText?: string;
   contentUrlLookup?: ContentUrlLookup;
   skipContentTypes?: string[];
+  maxTraverseDepth?: number;
 };
 
 export type CircularReference = {

--- a/packages/lastrev-build-prefetch-content/package.json
+++ b/packages/lastrev-build-prefetch-content/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@last-rev/build-prefetch-content",
-  "version": "5.5.2-alpha.2",
+  "version": "5.5.2-alpha.3",
   "description": "Prefetches global settings, path, and content mapping data",
   "main": "dist/index.js",
   "bin": {
@@ -45,8 +45,8 @@
     "typescript": "^3.9.7"
   },
   "dependencies": {
-    "@last-rev/adapter-contentful": "^4.3.2-alpha.0",
-    "@last-rev/integration-contentful": "^5.3.2-alpha.0",
+    "@last-rev/adapter-contentful": "^4.3.2-alpha.1",
+    "@last-rev/integration-contentful": "^5.3.2-alpha.1",
     "@types/ora": "^3.2.0",
     "contentful": "^8.1.7",
     "deepdash": "^5.3.2",

--- a/packages/lastrev-build-prefetch-content/package.json
+++ b/packages/lastrev-build-prefetch-content/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@last-rev/build-prefetch-content",
-  "version": "5.5.2-alpha.1",
+  "version": "5.5.2-alpha.2",
   "description": "Prefetches global settings, path, and content mapping data",
   "main": "dist/index.js",
   "bin": {
@@ -45,8 +45,8 @@
     "typescript": "^3.9.7"
   },
   "dependencies": {
-    "@last-rev/adapter-contentful": "^4.3.1",
-    "@last-rev/integration-contentful": "^5.3.1",
+    "@last-rev/adapter-contentful": "^4.3.2-alpha.0",
+    "@last-rev/integration-contentful": "^5.3.2-alpha.0",
     "@types/ora": "^3.2.0",
     "contentful": "^8.1.7",
     "deepdash": "^5.3.2",

--- a/packages/lastrev-content-validator/package-lock.json
+++ b/packages/lastrev-content-validator/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@last-rev/content-validator",
-  "version": "0.0.6-alpha.7",
+  "version": "0.0.6-alpha.8",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/packages/lastrev-content-validator/package.json
+++ b/packages/lastrev-content-validator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@last-rev/content-validator",
-  "version": "0.0.6-alpha.7",
+  "version": "0.0.6-alpha.8",
   "description": "Content validation heleprs for Contentful integration for lastrev projects",
   "main": "dist/index.js",
   "files": [

--- a/packages/lastrev-integration-contentful/package.json
+++ b/packages/lastrev-integration-contentful/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@last-rev/integration-contentful",
-  "version": "5.3.2-alpha.0",
+  "version": "5.3.2-alpha.1",
   "description": "Contentful integration for lastrev projects",
   "main": "dist/index.js",
   "files": [
@@ -53,7 +53,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.10.4",
-    "@last-rev/adapter-contentful": "^4.3.2-alpha.0",
+    "@last-rev/adapter-contentful": "^4.3.2-alpha.1",
     "@types/faker": "^4.1.12",
     "contentful": "^8.1.7",
     "deepdash": "^5.3.5",

--- a/packages/lastrev-integration-contentful/package.json
+++ b/packages/lastrev-integration-contentful/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@last-rev/integration-contentful",
-  "version": "5.3.1",
+  "version": "5.3.2-alpha.0",
   "description": "Contentful integration for lastrev projects",
   "main": "dist/index.js",
   "files": [
@@ -53,7 +53,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.10.4",
-    "@last-rev/adapter-contentful": "^4.3.1",
+    "@last-rev/adapter-contentful": "^4.3.2-alpha.0",
     "@types/faker": "^4.1.12",
     "contentful": "^8.1.7",
     "deepdash": "^5.3.5",


### PR DESCRIPTION
### Description
This PR adds support for circular references to the adapter transform function. 
This removes the necessity of removing them before passing them here. 

This helped fix an issue where removing circular references is not an option due to limits of Contentful stringifySafe function,
